### PR TITLE
Fix error data for BroadcastException.

### DIFF
--- a/src/Centrifugo.php
+++ b/src/Centrifugo.php
@@ -161,7 +161,10 @@ class Centrifugo implements CentrifugoInterface
         } catch (ClientException $e) {
             $result = [
                 'method' => $method,
-                'error'  => $e->getMessage(),
+                'error'  => [
+                    'message' => $e->getMessage(),
+                    'code'    => $e->getCode()
+                ],
                 'body'   => $json,
             ];
         } catch (ConnectException $e) {

--- a/src/Centrifugo.php
+++ b/src/Centrifugo.php
@@ -163,7 +163,7 @@ class Centrifugo implements CentrifugoInterface
                 'method' => $method,
                 'error'  => [
                     'message' => $e->getMessage(),
-                    'code'    => $e->getCode()
+                    'code'    => $e->getCode(),
                 ],
                 'body'   => $json,
             ];


### PR DESCRIPTION
If set wrong api key broadcasting returns error: "Cannot access offset of type string on string"
BroadcastException wait array with error code and message, but it returns only string with error message. 
