### PR TITLE
🐛  Fix `Undefined variable: private` error when channels empty

### DIFF
--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -41,6 +41,7 @@ class CentrifugoBroadcaster extends Broadcaster
             $client = $this->getClientFromRequest($request);
             $channels = $this->getChannelsFromRequest($request);
 
+            $private = false;
             $response = [];
             $privateResponse = [];
             foreach ($channels as $channel) {


### PR DESCRIPTION
Hi team,
I'm Ibrahim Hassan, Sr.Backend @salla.sa

We have an error when passing channels empty.
It hit in line 62, the private var is defined inside `foreach`, but if the channels are empty then it'll not be defined, so we need to predefine it before.

Error: `Undefined variable: private`


