### PR TITLE
TypeError fix

### DIFF
--- a/src/CentrifugoBroadcaster.php
+++ b/src/CentrifugoBroadcaster.php
@@ -42,7 +42,7 @@ class CentrifugoBroadcaster extends Broadcaster
      */
     public function auth($request): Response|Application|ResponseFactory
     {
-        $client = $request->user() ? $request->user()->id : '';
+        $client = $request->user() ? (string) $request->user()->id : '';
         $channel = $request->get('channel');
         $this->verifyUserCanAccessChannel($request, $channel);
 


### PR DESCRIPTION
Fixes "TypeError: Opekunov\Centrifugo\CentrifugoBroadcaster::makeResponseForClient(): Argument #2 ($userId) must be of type string, int given, called in /var/www/vendor/opekunov/laravel-centrifugo-broadcaster/src/CentrifugoBroadcaster.php on line 49" error