### PR TITLE
feat: add limit to history

### DIFF
--- a/src/Centrifugo.php
+++ b/src/Centrifugo.php
@@ -309,15 +309,34 @@ class Centrifugo implements CentrifugoInterface
      * Get channel history information (list of last messages sent into channel).
      *
      * @param string $channel
+     * @param int $limit = 0
+     * @param ?int $offset = null
+     * @param ?string $epoch = null
+     * @param bool $reverse = false
      *
      * @throws CentrifugoConnectionException
      * @throws CentrifugoException
      *
      * @return array
      */
-    public function history(string $channel): array
+    public function history(
+        string $channel,
+        int $limit = 0,
+        ?int $offset = null,
+        ?string $epoch = null,
+        bool $reverse = false
+    ): array
     {
-        return $this->send('history', ['channel' => $channel]);
+        $since = $offset !== null || $epoch !== null ? ['since' => [
+            'offset' => $offset,
+            'epoch' => $epoch,
+        ]] : [];
+
+        return $this->send('history', array_merge([
+            'channel' => $channel,
+            'limit' => $limit,
+            'reverse' => $reverse,
+        ], $since));
     }
 
     /**
@@ -335,6 +354,22 @@ class Centrifugo implements CentrifugoInterface
         return $this->send('history_remove', [
             'channel' => $channel,
         ]);
+    }
+
+    /**
+     * Remote procedure call
+     *
+     * @param string $method
+     * @param array $data = []
+     *
+     * @throws CentrifugoConnectionException
+     * @throws CentrifugoException
+     *
+     * @return array
+     */
+    public function rpc(string $method, array $data = []): array
+    {
+        return $this->send('rpc', ['method' => $method, 'data' => $data]);
     }
 
     /**

--- a/src/Contracts/CentrifugoInterface.php
+++ b/src/Contracts/CentrifugoInterface.php
@@ -16,7 +16,15 @@ interface CentrifugoInterface
 
     public function presenceStats(string $channel): array;
 
-    public function history(string $channel): array;
+    public function history(
+        string $channel,
+        int $limit = 0,
+        ?int $offset = null,
+        ?string $epoch = null,
+        bool $reverse = false
+    ): array;
+
+    public function rpc(string $method, array $data = []): array;
 
     public function historyRemove(string $channel): array;
 


### PR DESCRIPTION
Now, in fact, the feature with history does not work, since by default the limit is 0 and there is no result, this pr gives the ability to specify the limit and other settings

```php
public function history(
    string $channel,
    int $limit = 0,
    ?int $offset = null,
    ?string $epoch = null,
    bool $reverse = false
)
```